### PR TITLE
Fix payment method group icons

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -282,7 +282,7 @@ class Client
     /**
      * Returns an array of following grouped payment providers fields:
      * terms: Localized text with a link to the terms of payment.
-     * groups: Array of payment method group data (id, name, icon, providers)
+     * groups: Array of payment method group data (id, name, icon, svg, providers)
      *
      * @param int $amount Purchase amount in currency's minor unit.
      * @param string $locale
@@ -335,7 +335,8 @@ class Client
             return [
                 'id' => $group_data->id,
                 'name' => $group_data->name,
-                'icon' => $group_data->svg,
+                'icon' => $group_data->icon,
+                'svg' => $group_data->svg,
                 'providers' => array_map(function ($provider_data) {
                     return (new Provider())->bindProperties($provider_data);
                 }, $group_data->providers),


### PR DESCRIPTION
The [`GET /merchants/grouped-payment-providers`](https://paytrail.github.io/api-documentation/#/?id=list-grouped-providers) endpoint returns following data:

```
    PaymentMethodGroupDataWithProviders:
      allOf:
        - $ref: '#/components/schemas/PaymentMethodGroupData'
        - description: Localized name, icon and providers data for single payment method group
        - required:
            - id
            - name
            - icon
            - svg
            - providers
          properties:
            providers:
              type: array
              items:
                $ref: '#/components/schemas/PaymentMethodProvider'
```

However, the currently implemented library call `OpMerchantServices\SDK\Client->getGroupedPaymentProviders()` incorrectly handles the API response. The `svg` field is incorrectly named as `icon`, and the `svg` field, and the `icon` content are just dropped.

Currently the `groups` item in the returned `array` is:

```
array (
  0 => 
  array (
    'id' => 'bank',
    'name' => 'Pankkimaksutavat',
    'icon' => 'https://payment.checkout.fi/static/img/payment-groups/bank.svg',
    'providers' => ...
 ),
 ...
```

This PR fixes the `groups` item to include both the `icon` and `svg` fields from the API response data:

```
array (
  0 => 
  array (
    'id' => 'bank',
    'name' => 'Pankkimaksutavat',
    'icon' => 'https://payment.checkout.fi/static/img/payment-groups/bank.png',
    'svg' => 'https://payment.checkout.fi/static/img/payment-groups/bank.svg',
    'providers' => ...
 ),
 ...
```

Fixes #49 